### PR TITLE
Update nREPL requests.

### DIFF
--- a/expectations-mode.el
+++ b/expectations-mode.el
@@ -110,11 +110,16 @@
 (defun expectations-eval (string &optional handler stdout-handler synch)
   (if synch
       (funcall handler (current-buffer)
-               (plist-get (nrepl-send-string-sync string (cider-current-ns)) :value)
+               (plist-get (nrepl-sync-request:eval string (cider-current-connection) (cider-current-session) (cider-current-ns)) :value)
                synch)
-    (nrepl-send-string string
-                       (expectations-response-handler (or handler #'identity) stdout-handler)
-                       (cider-current-ns))))
+
+    (cider-nrepl-send-request
+     (list "op" "eval"
+           "ns"   (cider-current-ns)
+           "code" string
+           "session" (cider-current-session))
+     (expectations-response-handler (or handler #'identity) stdout-handler))))
+
 
 (defun expectations-test-clear (&optional callback synch)
   "Clear all counters and unmap generated vars for expectations"
@@ -257,8 +262,8 @@ it."
   (let* ((ns (match-string 2))
          (filename
           (read
-           (plist-get (nrepl-send-string-sync (format "(-> \"%s\" symbol ns-publics first val meta :file)" ns)
-                                              (cider-current-ns))
+           (plist-get (nrepl-sync-request:eval (format "(-> \"%s\" symbol ns-publics first val meta :file)" ns)
+                                              (cider-current-connection) (cider-current-session) (cider-current-ns) )
                       :value))))
     (list filename)))
 
@@ -324,7 +329,7 @@ it."
                                      (sort-by (comp :line meta) (vals (ns-publics (find-ns '%s))))))"
                      (line-number-at-pos)
                      (cider-current-ns))))
-    (plist-get (nrepl-send-string-sync clj (cider-current-ns)) :value)))
+    (plist-get (nrepl-sync-request:eval clj (cider-current-connection) (cider-current-session) (cider-current-ns)) :value)))
 
 (defun expectations-run-test (&optional synch)
   "Run test at point"


### PR DESCRIPTION
nrepl-send-string -> nrepl-request:eval
nrepl-send-string-sync -> nrepl-sync-request:eval

I needed these changes to run here. nREPL requests have changed, as can be seen here: https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md

any comment on this is helpful.